### PR TITLE
Allow to also be notified by parent attributes update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ on_attribute_update('foo', 'bar') do
   default['blah'] = node['foo']['bar']
 end
 # equivalent to
-on_attribute_update(%w[foo bar], init_on_registration: true) do
+on_attribute_update(%w[foo bar]) do
   default['blah'] = node['foo']['bar']
 end
 ```
@@ -35,10 +35,18 @@ on_attributes_update(%w[foo bar], 'blah') do
   default['all'] = node['foo']['bar'] + node['blah']
 end
 # equivalent to
-on_attributes_update(%w[foo bar], %w[blah], init_on_registration: true) do
+on_attributes_update(%w[foo bar], %w[blah]) do
   default['all'] = node['foo']['bar'] + node['blah']
 end
 ```
+
+### Options
+
+Option                  | Default | Description
+------------------------|:-------:|--------------------------------------
+*init\_on\_registration*| `true`  | Evaluate the block on registration.
+*observe_\parents*      | `true`  | Also observe parent attribute updates.
+
 
 ## Contributing
 

--- a/libraries/node_extension.rb
+++ b/libraries/node_extension.rb
@@ -4,16 +4,19 @@ require_relative 'update_dispatcher.rb'
 class Chef
   # Add extension methods on Chef Node
   class Node
-    def on_attribute_update(*path, init_on_registration: true, &block)
+    def on_attribute_update(*path, init_on_registration: true, observe_parents: true, &block)
       path = path.first if path.is_a?(::Array) && path.one?
-      on_attributes_update(path, init_on_registration: init_on_registration, &block)
+      on_attributes_update(path,
+                           init_on_registration: init_on_registration,
+                           observe_parents:      observe_parents,
+                           &block)
     end
 
-    def on_attributes_update(*paths, init_on_registration: true, &block)
+    def on_attributes_update(*paths, init_on_registration: true, observe_parents: true, &block)
       raise ::ArgumentError, 'no block given' if block.nil?
       paths = paths.map { |path| ::Kernel.Array(path) }
                    .each { |path| ::ChefUpdatableAttributes.validate_path!(path) }
-      ::ChefUpdatableAttributes::UpdateDispatcher.register(self, *paths, &block)
+      ::ChefUpdatableAttributes::UpdateDispatcher.register(self, *paths, observe_parents: observe_parents, &block)
       yield nil, nil, nil if init_on_registration
     end
   end

--- a/spec/unit/libraries/node_extension_spec.rb
+++ b/spec/unit/libraries/node_extension_spec.rb
@@ -9,9 +9,12 @@ describe ::Chef::Node do
 
   describe '#on_attribute_update' do
     it 'registers the handler on the UpdateDispatcher' do
-      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register).with(node, paths[0], &handlers[0]).ordered
-      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register).with(node, paths[1], &handlers[1]).ordered
-      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register).with(node, paths[2], &handlers[2]).ordered
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, paths[0], anything, &handlers[0]).ordered
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, paths[1], anything, &handlers[1]).ordered
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, paths[2], anything, &handlers[2]).ordered
 
       subject.on_attribute_update(*paths[0], &handlers[0])
       subject.on_attribute_update(*paths[1], &handlers[1])
@@ -29,12 +32,27 @@ describe ::Chef::Node do
         expect { |b| subject.on_attribute_update(*paths[0], init_on_registration: false, &b) }.not_to yield_control
       end
     end
+
+    it 'passes observe_parents to the registration call' do
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, paths[0], observe_parents: true) { |&b| expect(b).to eq handlers[0] }.ordered
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, paths[1], observe_parents: true) { |&b| expect(b).to eq handlers[1] }.ordered
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, paths[2], observe_parents: false) { |&b| expect(b).to eq handlers[2] }.ordered
+
+      subject.on_attribute_update(*paths[0], &handlers[0])
+      subject.on_attribute_update(*paths[1], observe_parents: true, &handlers[1])
+      subject.on_attribute_update(*paths[2], observe_parents: false, &handlers[2])
+    end
   end
 
   describe '#on_attributes_update' do
     it 'registers the handlers on the UpdateDispatcher' do
-      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register).with(node, paths[0], &handlers[0]).ordered
-      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register).with(node, *paths, &handlers[0]).ordered
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, paths[0], anything, &handlers[0]).ordered
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, *paths, anything, &handlers[0]).ordered
 
       subject.on_attributes_update(paths[0], &handlers[0])
       subject.on_attributes_update(paths[0], paths[1], paths[2], &handlers[0])
@@ -50,6 +68,19 @@ describe ::Chef::Node do
       it 'does not call the handler' do
         expect { |b| subject.on_attributes_update(*paths, init_on_registration: false, &b) }.not_to yield_control
       end
+    end
+
+    it 'passes observe_parents to the registration call' do
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, *paths, observe_parents: true) { |&b| expect(b).to eq handlers[0] }.ordered
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, *paths, observe_parents: true) { |&b| expect(b).to eq handlers[1] }.ordered
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, *paths, observe_parents: false) { |&b| expect(b).to eq handlers[2] }.ordered
+
+      subject.on_attributes_update(*paths, &handlers[0])
+      subject.on_attributes_update(*paths, observe_parents: true, &handlers[1])
+      subject.on_attributes_update(*paths, observe_parents: false, &handlers[2])
     end
   end
 end


### PR DESCRIPTION
When listening "foo.bar" attribute, it is not rare to also want to be notified when "foo" is updated; as sometimes it could completely remove "foo.bar".

This is now the default & the optional parameter "observe_parent_path" allows to control this behavior.