### PR TITLE
Allow configurable recursion depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Option                  | Default | Description
 ------------------------|:-------:|--------------------------------------
 *init\_on\_registration*| `true`  | Evaluate the block on registration.
 *observe_\parents*      | `true`  | Also observe parent attribute updates.
+*recursion*             | `0`     | Configure allowed level of recursion.
 
 
 ## Contributing

--- a/libraries/node_extension.rb
+++ b/libraries/node_extension.rb
@@ -4,19 +4,24 @@ require_relative 'update_dispatcher.rb'
 class Chef
   # Add extension methods on Chef Node
   class Node
-    def on_attribute_update(*path, init_on_registration: true, observe_parents: true, &block)
+    def on_attribute_update(*path, init_on_registration: true, observe_parents: true, recursion: 0, &block)
       path = path.first if path.is_a?(::Array) && path.one?
       on_attributes_update(path,
                            init_on_registration: init_on_registration,
                            observe_parents:      observe_parents,
+                           recursion:            recursion,
                            &block)
     end
 
-    def on_attributes_update(*paths, init_on_registration: true, observe_parents: true, &block)
+    def on_attributes_update(*paths, init_on_registration: true, observe_parents: true, recursion: 0, &block)
       raise ::ArgumentError, 'no block given' if block.nil?
       paths = paths.map { |path| ::Kernel.Array(path) }
                    .each { |path| ::ChefUpdatableAttributes.validate_path!(path) }
-      ::ChefUpdatableAttributes::UpdateDispatcher.register(self, *paths, observe_parents: observe_parents, &block)
+      ::ChefUpdatableAttributes::UpdateDispatcher.register(self,
+                                                           *paths,
+                                                           observe_parents: observe_parents,
+                                                           recursion:       recursion,
+                                                           &block)
       yield nil, nil, nil if init_on_registration
     end
   end

--- a/libraries/update_dispatcher.rb
+++ b/libraries/update_dispatcher.rb
@@ -5,12 +5,14 @@ module ChefUpdatableAttributes
 
     # Holds attribute update subscription info
     class Subscription
-      attr_reader :path, :callback, :attribute_value
+      attr_reader :path, :callback, :attribute_value, :max_depth, :current_depth
 
-      def initialize(observed_path, value = nil, &callback)
+      def initialize(observed_path, value = nil, recursion = 0, &callback)
         @attribute_value = value
         @path = observed_path.dup.freeze
         @callback = callback
+        @max_depth = recursion
+        @current_depth = 0
       end
 
       def source_location
@@ -22,8 +24,10 @@ module ChefUpdatableAttributes
 
         return false if new_value == previous_value
 
+        @current_depth += 1
         @attribute_value = new_value
         @callback.call(precedence, @path, new_value, previous_value)
+        @current_depth -= 1
 
         true
       end
@@ -32,7 +36,7 @@ module ChefUpdatableAttributes
     def initialize(node, setup: true)
       super()
       @node = node
-      @stack = ::Hash.new
+      @stack = []
       @subscriptions = ::Hash.new { |h, k| h[k] = [] }
 
       setup_event_handler if setup
@@ -42,31 +46,32 @@ module ChefUpdatableAttributes
       @node.run_context.events.register(self)
     end
 
-    def attribute_changed(precedence, path, _value)
+    def attribute_changed(precedence, path, value)
       # Return to avoid auto-vivication of the subscriptions hash
       return unless @subscriptions.key?(path)
 
       @subscriptions[path].each do |subscription|
         location = subscription.source_location
-        raise UpdateLoop, <<~MESSAGE if @stack.key?(location)
+        @stack << "#{location} with (#{precedence.inspect}, #{path.inspect}, #{value.inspect})"
+
+        raise UpdateLoop, <<~MESSAGE if subscription.current_depth > subscription.max_depth
           a loop has been detected during Attribute update!
 
           Multiple notifications of the block defined at #{location.join(':')}.
           Here is the current notification stack:
-          #{@stack}
+          #{@stack.join("\n")}
         MESSAGE
 
-        @stack[location] = path
         subscription.notify(precedence, @node.read(*subscription.path))
-        @stack.delete(location)
+        @stack.pop
       end
     end
 
-    def register(path, observe_parents: true, &block)
+    def register(path, observe_parents: true, recursion: 0, &block)
       raise ::ArgumentError, 'no block given' if block.nil?
 
       path = ::Kernel.Array(path)
-      subscription = Subscription.new(path, @node.read(*path), &block)
+      subscription = Subscription.new(path, @node.read(*path), recursion, &block)
 
       key_lengths = observe_parents ? (1..path.size) : [path.size]
       key_lengths.each { |length| @subscriptions[path[0...length]] << subscription }
@@ -74,10 +79,10 @@ module ChefUpdatableAttributes
       subscription
     end
 
-    def self.register(node, *paths, observe_parents: true, &block)
+    def self.register(node, *paths, observe_parents: true, recursion: 0, &block)
       dispatcher = node.run_context.events.subscribers.find { |s| s.is_a? UpdateDispatcher }
       dispatcher ||= new(node)
-      paths.each { |p| dispatcher.register(p, observe_parents: observe_parents, &block) }
+      paths.each { |p| dispatcher.register(p, observe_parents: observe_parents, recursion: recursion, &block) }
     end
   end
 end

--- a/spec/unit/libraries/node_extension_spec.rb
+++ b/spec/unit/libraries/node_extension_spec.rb
@@ -35,15 +35,28 @@ describe ::Chef::Node do
 
     it 'passes observe_parents to the registration call' do
       expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
-        .with(node, paths[0], observe_parents: true) { |&b| expect(b).to eq handlers[0] }.ordered
+        .with(node, paths[0], observe_parents: true, recursion: 0) { |&b| expect(b).to eq handlers[0] }.ordered
       expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
-        .with(node, paths[1], observe_parents: true) { |&b| expect(b).to eq handlers[1] }.ordered
+        .with(node, paths[1], observe_parents: true, recursion: 0) { |&b| expect(b).to eq handlers[1] }.ordered
       expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
-        .with(node, paths[2], observe_parents: false) { |&b| expect(b).to eq handlers[2] }.ordered
+        .with(node, paths[2], observe_parents: false, recursion: 0) { |&b| expect(b).to eq handlers[2] }.ordered
 
       subject.on_attribute_update(*paths[0], &handlers[0])
       subject.on_attribute_update(*paths[1], observe_parents: true, &handlers[1])
       subject.on_attribute_update(*paths[2], observe_parents: false, &handlers[2])
+    end
+
+    it 'passes recursion to the registration call' do
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, paths[0], observe_parents: true, recursion: 0) { |&b| expect(b).to eq handlers[0] }.ordered
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, paths[1], observe_parents: true, recursion: 1) { |&b| expect(b).to eq handlers[1] }.ordered
+      expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
+        .with(node, paths[2], observe_parents: true, recursion: 5) { |&b| expect(b).to eq handlers[2] }.ordered
+
+      subject.on_attribute_update(*paths[0], &handlers[0])
+      subject.on_attribute_update(*paths[1], recursion: 1, &handlers[1])
+      subject.on_attribute_update(*paths[2], recursion: 5, &handlers[2])
     end
   end
 
@@ -72,11 +85,11 @@ describe ::Chef::Node do
 
     it 'passes observe_parents to the registration call' do
       expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
-        .with(node, *paths, observe_parents: true) { |&b| expect(b).to eq handlers[0] }.ordered
+        .with(node, *paths, observe_parents: true, recursion: 0) { |&b| expect(b).to eq handlers[0] }.ordered
       expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
-        .with(node, *paths, observe_parents: true) { |&b| expect(b).to eq handlers[1] }.ordered
+        .with(node, *paths, observe_parents: true, recursion: 0) { |&b| expect(b).to eq handlers[1] }.ordered
       expect(::ChefUpdatableAttributes::UpdateDispatcher).to receive(:register)
-        .with(node, *paths, observe_parents: false) { |&b| expect(b).to eq handlers[2] }.ordered
+        .with(node, *paths, observe_parents: false, recursion: 0) { |&b| expect(b).to eq handlers[2] }.ordered
 
       subject.on_attributes_update(*paths, &handlers[0])
       subject.on_attributes_update(*paths, observe_parents: true, &handlers[1])


### PR DESCRIPTION
In certain cases you may want to edit the observed attributes inside the event handler block.
The original implementation was forbidding this by raising Updateloop.

Now you can explicitly allow that kind of case or more complexe ones by simply specifying desired recursion depth using the 'recursion' named argument.

e.g.

```ruby
  on_attribute_update('important', recursion: 1) do
    default['important'] = node['important'].to_s.upcase
  end```